### PR TITLE
Refactor unzipToTempDir with security checks and limits

### DIFF
--- a/app/src/main/java/org/nqmgaming/aneko/presentation/AnekoViewModel.kt
+++ b/app/src/main/java/org/nqmgaming/aneko/presentation/AnekoViewModel.kt
@@ -460,32 +460,57 @@ class AnekoViewModel @Inject constructor(
         return null
     }
 
+    private companion object {
+    const val MAX_ZIP_ENTRIES = 200
+    const val MAX_ZIP_BYTES   = 50L * 1024 * 1024
+}
 
-    fun unzipToTempDir(input: InputStream, tempDir: File): List<File> {
-        val zis = ZipInputStream(BufferedInputStream(input))
-        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
-        val extractedFiles = mutableListOf<File>()
+fun unzipToTempDir(input: InputStream, tempDir: File): List<File> {
+    val canonicalBase = tempDir.canonicalPath + File.separator
+    val buffer        = ByteArray(DEFAULT_BUFFER_SIZE)
+    val extracted     = mutableListOf<File>()
+    var entryCount    = 0
+    var totalBytes    = 0L
 
+    ZipInputStream(BufferedInputStream(input)).use { zis ->
         var entry = zis.nextEntry
         while (entry != null) {
-            if (!entry.isDirectory && !entry.name.startsWith("__MACOSX") && !entry.name.endsWith(".DS_Store")) {
-                val outFile = File(tempDir, entry.name)
+            if (++entryCount > MAX_ZIP_ENTRIES)
+                throw SecurityException()
+
+            val name = entry.name
+            val skip = entry.isDirectory
+                || name.startsWith("__MACOSX")
+                || name.endsWith(".DS_Store")
+
+            if (!skip) {
+                if (name.startsWith("/") || name.startsWith("\\")
+                        || name.contains(".."))
+                    throw SecurityException()
+
+                val outFile = File(tempDir, name)
+                if (!outFile.canonicalPath.startsWith(canonicalBase))
+                    throw SecurityException()
+
                 outFile.parentFile?.mkdirs()
+
                 BufferedOutputStream(FileOutputStream(outFile)).use { bos ->
                     var count: Int
                     while (zis.read(buffer).also { count = it } != -1) {
+                        totalBytes += count
+                        if (totalBytes > MAX_ZIP_BYTES)
+                            throw SecurityException()
                         bos.write(buffer, 0, count)
                     }
                 }
-                extractedFiles.add(outFile)
+                extracted.add(outFile)
             }
             zis.closeEntry()
             entry = zis.nextEntry
         }
-
-        zis.close()
-        return extractedFiles
     }
+    return extracted
+}
 
     fun moveSkinFilesToFinalDestination(sourceDir: File, destDir: File, overwrite: Boolean) {
         sourceDir.walkTopDown().forEach { file ->


### PR DESCRIPTION
Fixed path traversal and zip bomb crashes

I left loose limits because I don't know the exact range of the skins. Please review the proposal and correct what is necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security validation for zip file extraction to prevent malicious or corrupted archives from causing harm. Added safeguards including entry count limits, file size restrictions, and path traversal attack prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->